### PR TITLE
Added --running and --stopped options

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ You can specify the CT list by providing the `--ct-list` command-line option or 
 
 You can specify the VM list by providing the `--vm-list` command-line option or by setting the `PVE_VM_LIST` environment variable.
 
-By default, CT/VM lists default to `none`, meaning that no CTs/VMs are selected. To specify all CTs/VMs pass `all` as parameter, like `--ct-list=all`.
+By default, CT/VM lists default to `none`, meaning that no CTs/VMs are selected. You can specify 'all', 'running' or 'stopped' to pass the list of all, running or stopped  CTs/VMs.
 
-You can specify `--all` to select all CT/VM.
+You can specify `--all`, '--running' or '--stopped' to automatically set the corresponding value for both '--ct-list' and '--vm-list' options.
 
 ## Installation
 
@@ -94,3 +94,16 @@ ct1001 : delsnapshot STABLE has succeeded
 ct1002 : delsnapshot STABLE has succeeded
 ct1003 : delsnapshot STABLE has succeeded
 ```
+
+Shutdown all running VMs:
+
+```
+pve-bulk shutdown --vm-list=running
+```
+
+Stop all running VMs/CTs:
+
+```
+pve-bulk stop --running
+```
+

--- a/bin/pve-bulk
+++ b/bin/pve-bulk
@@ -105,6 +105,14 @@ do
             pve_ct_list='all'
             pve_vm_list='all'
             ;;
+        --running)
+            pve_ct_list='running'
+            pve_vm_list='running'
+            ;;
+        --stopped)
+            pve_ct_list='stopped'
+            pve_vm_list='stopped'
+            ;;
         --help)
             opt_usage='yes'
             ;;
@@ -139,9 +147,11 @@ Actions:
 Options:
 
     --help
-    --ct-list={ctid,...}    ct list (defaults to 'none'; specify 'all' to select all CTs as with pct list)
-    --vm-list={vmid,...}    vm list (defaults to 'none'; specify 'all' to select all VMs as with qm list)
+    --ct-list={ctid,...}    ct list (defaults to 'none'; specify 'all' to select all CTs as with pct list, 'running' to select all running CTs or 'stopped' to select all stopped CTs)
+    --vm-list={vmid,...}    vm list (defaults to 'none'; specify 'all' to select all VMs as with qm list, 'running' to select all running CTs or 'stopped' to select all stopped VMs)
     --all                   set ct-list and vm-list to 'all'
+    --running               set ct-list and vm-list to 'running'
+    --stopped               set ct-list and vm-list to 'stopped'
 
 Environment variables:
 
@@ -198,6 +208,12 @@ then
 elif [ "${pve_ct_list}" = 'all' ]
 then
     pve_ct_list=$(${pve_ct_manager} list | grep -v 'VMID' | awk '{ print $1 }')
+elif [ "${pve_ct_list}" = 'running' ]
+then
+    pve_ct_list=$(${pve_ct_manager} list | grep -v 'VMID' | grep 'running' | awk '{ print $1 }')
+elif [ "${pve_ct_list}" = 'stopped' ]
+then
+    pve_ct_list=$(${pve_ct_manager} list | grep -v 'VMID' | grep 'stopped' | awk '{ print $1 }')
 else
     pve_ct_list=$(echo "${pve_ct_list}" | tr ',' ' ')
 fi
@@ -212,6 +228,12 @@ then
 elif [ "${pve_vm_list}" = 'all' ]
 then
     pve_vm_list=$(${pve_vm_manager} list | grep -v 'VMID' | awk '{ print $1 }')
+elif [ "${pve_vm_list}" = 'running' ]
+then
+    pve_vm_list=$(${pve_vm_manager} list | grep -v 'VMID' | grep 'running' | awk '{ print $1 }')
+elif [ "${pve_vm_list}" = 'stopped' ]
+then
+    pve_vm_list=$(${pve_vm_manager} list | grep -v 'VMID' | grep 'stopped' | awk '{ print $1 }')
 else
     pve_vm_list=$(echo "${pve_vm_list}" | tr ',' ' ')
 fi


### PR DESCRIPTION
I've added --running and --stopped options with corresponding --ct-list an…d --vm-list 'running' and 'stopped' values. This allows to avoid sending commands like shutdown to already stopped VMs or CTs, or commands like start to already started VMs or CTs, making command execution faster.